### PR TITLE
Adjusting type processing to appropriately handle null values

### DIFF
--- a/Snowflake.Data/Client/SnowflakeDbCommand.cs
+++ b/Snowflake.Data/Client/SnowflakeDbCommand.cs
@@ -132,7 +132,7 @@ namespace Snowflake.Data.Client
         {
             SFBaseResultSet resultSet = executeInternal(CommandText, null, false);
             resultSet.next();
-            return resultSet.getValue(0);
+            return resultSet.GetValue(0);
         }
 
         public override void Prepare()

--- a/Snowflake.Data/Client/SnowflakeDbDataReader.cs
+++ b/Snowflake.Data/Client/SnowflakeDbDataReader.cs
@@ -32,7 +32,7 @@ namespace Snowflake.Data.Client
         {
             get
             {
-                return resultSet.getValue(GetOrdinal(name));
+                return resultSet.GetValue(GetOrdinal(name));
             }
         }
 
@@ -40,7 +40,7 @@ namespace Snowflake.Data.Client
         {
             get
             {
-                return resultSet.getValue(ordinal);
+                return resultSet.GetValue(ordinal);
             }
         }
 
@@ -88,12 +88,12 @@ namespace Snowflake.Data.Client
 
         public override bool GetBoolean(int ordinal)
         {
-            return resultSet.getBoolean(ordinal);
+            return resultSet.GetValue<bool>(ordinal);
         }
 
         public override byte GetByte(int ordinal)
         {
-            byte[] bytes = resultSet.getBytes(ordinal);
+            byte[] bytes = resultSet.GetValue<byte[]>(ordinal);
             return bytes[0];
         }
 
@@ -104,7 +104,7 @@ namespace Snowflake.Data.Client
 
         public override char GetChar(int ordinal)
         {
-            string val = resultSet.getString(ordinal);
+            string val = resultSet.GetString(ordinal);
             return val[0];
         }
 
@@ -120,17 +120,17 @@ namespace Snowflake.Data.Client
 
         public override DateTime GetDateTime(int ordinal)
         {
-            return resultSet.getDateTime(ordinal);
+            return resultSet.GetValue<DateTime>(ordinal);
         }
 
         public override decimal GetDecimal(int ordinal)
         {
-            return resultSet.getDecimal(ordinal);
+            return resultSet.GetValue<decimal>(ordinal);
         }
 
         public override double GetDouble(int ordinal)
         {
-            return resultSet.getDouble(ordinal);
+            return resultSet.GetValue<double>(ordinal);
         }
 
         public override IEnumerator GetEnumerator()
@@ -145,27 +145,27 @@ namespace Snowflake.Data.Client
 
         public override float GetFloat(int ordinal)
         {
-            return resultSet.getFloat(ordinal);
+            return resultSet.GetValue<float>(ordinal);
         }
 
         public override Guid GetGuid(int ordinal)
         {
-            return resultSet.getGuid(ordinal);
+            return resultSet.GetValue<Guid>(ordinal);
         }
 
         public override short GetInt16(int ordinal)
         {
-            return resultSet.getInt16(ordinal);
+            return resultSet.GetValue<short>(ordinal);
         }
 
         public override int GetInt32(int ordinal)
         {
-            return resultSet.getInt32(ordinal);
+            return resultSet.GetValue<int>(ordinal);
         }
 
         public override long GetInt64(int ordinal)
         {
-            return resultSet.getInt64(ordinal);
+            return resultSet.GetValue<long>(ordinal);
         }
 
         public override string GetName(int ordinal)
@@ -180,12 +180,12 @@ namespace Snowflake.Data.Client
 
         public override string GetString(int ordinal)
         {
-            return resultSet.getString(ordinal);
+            return resultSet.GetString(ordinal);
         }
 
         public override object GetValue(int ordinal)
         {
-            return resultSet.getValue(ordinal);
+            return resultSet.GetValue(ordinal);
         }
 
         public override int GetValues(object[] values)
@@ -200,7 +200,7 @@ namespace Snowflake.Data.Client
 
         public override bool IsDBNull(int ordinal)
         {
-            return resultSet.getValue(ordinal) == null;
+            return resultSet.GetValue(ordinal) == DBNull.Value;
         }
 
         public override bool NextResult()

--- a/Snowflake.Data/Core/ResultSetUtil.cs
+++ b/Snowflake.Data/Core/ResultSetUtil.cs
@@ -27,11 +27,11 @@ namespace Snowflake.Data.Core
                 case SFStatementType.MULTI_INSERT:
                     for(int i=0; i<resultSet.columnCount; i++)
                     {
-                        updateCount += resultSet.getInt32(i);
+                        updateCount += resultSet.GetValue<int>(i);
                     }
                     break;
                 case SFStatementType.COPY:
-                    updateCount = resultSet.getInt32(3);
+                    updateCount = resultSet.GetValue<int>(3);
                     break;
                 case SFStatementType.SELECT:
                     updateCount = -1;

--- a/Snowflake.Data/Core/SFBaseResultSet.cs
+++ b/Snowflake.Data/Core/SFBaseResultSet.cs
@@ -1,4 +1,4 @@
-﻿/*
+﻿/*1/
  * Copyright (c) 2012-2017 Snowflake Computing Inc. All rights reserved.
  */
 
@@ -24,134 +24,33 @@ namespace Snowflake.Data.Core
 
         protected abstract string getObjectInternal(int columnIndex);
 
-        internal byte[] getBytes(int columnIndex)
+        internal T GetValue<T>(int columnIndex)
         {
-            string val = getObjectInternal(columnIndex);
-            SFDataType sfDataType = sfResultSetMetaData.getColumnTypeByIndex(columnIndex);
-            return (byte[])SFDataConverter.convertToCSharpVal(val, sfDataType, typeof(byte[]));
+            return (T) GetValue(columnIndex);
         }
 
-        internal DateTime getDateTime(int columnIndex)
+        internal string GetString(int columnIndex)
         {
-            string val = getObjectInternal(columnIndex);
-            SFDataType sfDataType = sfResultSetMetaData.getColumnTypeByIndex(columnIndex);
-            return (DateTime)SFDataConverter.convertToCSharpVal(val, sfDataType, typeof(DateTime));
-        }
-
-        internal Decimal getDecimal(int columnIndex)
-        {
-            string val = getObjectInternal(columnIndex);
-            SFDataType sfDataType = sfResultSetMetaData.getColumnTypeByIndex(columnIndex);
-            return (Decimal)SFDataConverter.convertToCSharpVal(val, sfDataType, typeof(Decimal));
-        }
-        internal double getDouble(int columnIndex)
-        {
-            string val = getObjectInternal(columnIndex);
-            SFDataType sfDataType = sfResultSetMetaData.getColumnTypeByIndex(columnIndex);
-            return (double)SFDataConverter.convertToCSharpVal(val, sfDataType ,typeof(double));
-        }
-        internal float getFloat(int columnIndex)
-        {
-            string val = getObjectInternal(columnIndex);
-            SFDataType sfDataType = sfResultSetMetaData.getColumnTypeByIndex(columnIndex);
-            return (float)SFDataConverter.convertToCSharpVal(val, sfDataType, typeof(float));
-        }
-        internal Guid getGuid(int columnIndex)
-        {
-            string val = getObjectInternal(columnIndex);
-            SFDataType sfDataType = sfResultSetMetaData.getColumnTypeByIndex(columnIndex);
-            return (Guid)SFDataConverter.convertToCSharpVal(val, sfDataType, typeof(Guid));
-        }
-
-        internal string getString(int columnIndex)
-        {
-            SFDataType sfDataType = sfResultSetMetaData.getColumnTypeByIndex(columnIndex);
-
-            switch(sfDataType)
+            var type = sfResultSetMetaData.getColumnTypeByIndex(columnIndex);
+            switch (type)
             {
                 case SFDataType.DATE:
-                    return SFDataConverter.toDateString(getDateTime(columnIndex), 
+                    var val = GetValue(columnIndex);
+                    if (val == null)
+                        return null;
+                    return SFDataConverter.toDateString((DateTime)val, 
                         sfResultSetMetaData.dateOutputFormat);
+                //TODO: Feels like were missing some implementations here, at least for time?
                 default:
-                    return getObjectInternal(columnIndex);
+                    return getObjectInternal(columnIndex); 
             }
         }
 
-        internal short getInt16(int columnIndex)
+        internal object GetValue(int columnIndex)
         {
             string val = getObjectInternal(columnIndex);
-            SFDataType sfDataType = sfResultSetMetaData.getColumnTypeByIndex(columnIndex);
-            return (Int16) SFDataConverter.convertToCSharpVal(val, sfDataType, typeof(Int16));
-        }
-
-        internal int getInt32(int columnIndex)
-        {
-            string val = getObjectInternal(columnIndex);
-            SFDataType sfDataType = sfResultSetMetaData.getColumnTypeByIndex(columnIndex);
-            return (Int32) SFDataConverter.convertToCSharpVal(val, sfDataType, typeof(Int32));
-        }
-
-        internal long getInt64(int columnIndex)
-        {
-            string val = getObjectInternal(columnIndex);
-            SFDataType sfDataType = sfResultSetMetaData.getColumnTypeByIndex(columnIndex);
-            return (Int64) SFDataConverter.convertToCSharpVal(val, sfDataType, typeof(Int64));
-        }
-
-        internal bool getBoolean(int columnIndex)
-        {
-            string val = getObjectInternal(columnIndex);
-            SFDataType sfDataType = sfResultSetMetaData.getColumnTypeByIndex(columnIndex);
-            return (bool)SFDataConverter.convertToCSharpVal(val, sfDataType, typeof(Boolean));
-        }
-
-        internal DateTimeOffset getDateTimeOffset(int columnIndex)
-        {
-            string val = getObjectInternal(columnIndex);
-            SFDataType sfDataType = sfResultSetMetaData.getColumnTypeByIndex(columnIndex);
-            return (DateTimeOffset) SFDataConverter.convertToCSharpVal(
-                        val, sfDataType, typeof(DateTimeOffset));
-        }
-
-        internal object getValue(int columnIndex)
-        {
-            Type type = sfResultSetMetaData.getCSharpTypeByIndex(columnIndex);
-            if (type == typeof(long))
-            {
-                return getInt64(columnIndex);
-            }
-            else if (type == typeof(decimal))
-            {
-                return getDecimal(columnIndex);
-            }
-            else if (type == typeof(string))
-            {
-                return getString(columnIndex);
-            }
-            else if (type == typeof(byte))
-            {
-                return getBytes(columnIndex);
-            }
-            else if (type == typeof(double))
-            {
-                return getDouble(columnIndex);
-            }
-            else if (type == typeof(DateTime))
-            {
-                return getDateTime(columnIndex);
-            }
-            else if (type == typeof(DateTimeOffset))
-            {
-                return getDateTimeOffset(columnIndex);
-            }
-            else if (type == typeof(bool))
-            {
-                return getBoolean(columnIndex);
-            }
-            else
-            { 
-                throw new NotImplementedException();
-            }
+            var types = sfResultSetMetaData.GetTypesByIndex(columnIndex);
+            return SFDataConverter.ConvertToCSharpVal(val, types.Item1, types.Item2);
         }
         
         internal void close()


### PR DESCRIPTION
Made some changes to the SFBaseResultSet to return DBNull.Value when the column contains null.